### PR TITLE
Adding grid view - v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+/.vscode

--- a/src/App.css
+++ b/src/App.css
@@ -1,43 +1,43 @@
 /* Structure */
 .App-header {
-  background-color: #ac3931;
-  padding: 0 20px;
-  display: flex;
-  flex-direction: column;
+	background-color: #ac3931;
+	padding: 0 20px;
+	display: flex;
+	flex-direction: column;
 }
 
 .App-header h1 {
-  font-size: calc(10px + 2vmin);
-  color: white;
+	font-size: calc(10px + 2vmin);
+	color: white;
 }
 
 .App-header div div:nth-child(2) {
-  padding-top: 20px;
-  text-align: right;
-  margin: 0;
+	padding-top: 20px;
+	text-align: right;
+	margin: 0;
 }
 
 .App-header button {
-  background: #537d8d;
+	background: #537d8d;
 }
 
 .App-body {
-  padding: 20px;
-  color: #482c3d;
+	padding: 20px;
+	color: #482c3d;
 }
 
 /* Bits */
 @media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-    height: 20vmin;
-  }
+	.App-logo {
+		animation: App-logo-spin infinite 20s linear;
+		height: 20vmin;
+	}
 }
 @keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(360deg);
+	}
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,30 +22,17 @@ export default function App() {
 
   const tabs = {
     0: <Charts></Charts>,
-    1: <Grids></Grids>,
+    1: <Grids cleanTransactions={cleanTransactions}></Grids>,
     2: <Transactions cleanTransactions={cleanTransactions}></Transactions>,
   };
 
   type tabOptions = keyof typeof tabs;
 
-  const [currentTab, setCurrentTab] = React.useState<tabOptions>(2);
+  const [currentTab, setCurrentTab] = React.useState<tabOptions>(1);
 
   // LOADING
   React.useEffect(() => {
-    axios.get(`${process.env.REACT_APP_GSHEET_URL}?key=${process.env.REACT_APP_GAPI_KEY}`)
-      .then(res => {
-        const data = res.data;
-        setCleanTransactions(
-          data.values
-            .slice(1)
-            .map(([index, date, description, , , amount, category]: [number, string, string, any, any, number, category]) =>
-              {return {index, date, description, category, amount};}
-            )
-        )
-      })
-      .catch((err) => {
-        console.log("error");
-      });
+    getGSheetData();
   }, []);
 
   console.log("Clean transactions: ", cleanTransactions);
@@ -61,24 +48,31 @@ export default function App() {
             <ButtonGroup variant="contained" color="primary">
               <Button
                 onClick={() => {
+                  getGSheetData();
+                }}
+              >
+                <span className="material-icons">refresh</span>
+              </Button>
+              <Button
+                onClick={() => {
                   setCurrentTab(0);
                 }}
               >
-                Charts
+                <span className="material-icons">insights</span>&nbsp;&nbsp;Chart
               </Button>
               <Button
                 onClick={() => {
                   setCurrentTab(1);
                 }}
               >
-                Grid
+                <span className="material-icons">apps</span>&nbsp;&nbsp;Grid
               </Button>
               <Button
                 onClick={() => {
                   setCurrentTab(2);
                 }}
               >
-                Transactions
+                <span className="material-icons">segment</span>&nbsp;&nbsp;Transactions
               </Button>
             </ButtonGroup>
           </Grid>
@@ -87,4 +81,22 @@ export default function App() {
       <div className="App-body">{tabs[currentTab]}</div>
     </div>
   );
+
+  // HELPERS
+  function getGSheetData() {
+    axios.get(`${process.env.REACT_APP_GSHEET_URL}?key=${process.env.REACT_APP_GAPI_KEY}`)
+    .then(res => {
+      const data = res.data;
+      setCleanTransactions(
+        data.values
+          .slice(1)
+          .map(([index, date, description, , , amount, category]: [number, string, string, any, any, string, category]) =>
+            {return {index, date, description, category, amount: parseInt(amount)};}
+          )
+      )
+    })
+    .catch((err) => {
+      console.log("error");
+    });
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 // Libs
 import * as React from "react";
 import axios from 'axios';
+import { ThemeProvider } from '@material-ui/core/styles';
 import { Grid, ButtonGroup, Button } from "@material-ui/core";
 import "@fontsource/roboto";
 import "@fontsource/material-icons";
@@ -13,6 +14,7 @@ import Transactions from "./components/Transactions/Transactions";
 // Assets
 import { iTransaction, category } from "./types";
 import "./App.css";
+import { theme } from "./theme";
 
 export default function App() {
   // Definitions
@@ -30,6 +32,8 @@ export default function App() {
 
   const [currentTab, setCurrentTab] = React.useState<tabOptions>(1);
 
+
+
   // LOADING
   React.useEffect(() => {
     getGSheetData();
@@ -38,6 +42,7 @@ export default function App() {
   console.log("Clean transactions: ", cleanTransactions);
   // RENDER
   return (
+    <ThemeProvider theme={theme}>
     <div className="App">
       <header className="App-header">
         <Grid container>
@@ -80,6 +85,7 @@ export default function App() {
       </header>
       <div className="App-body">{tabs[currentTab]}</div>
     </div>
+    </ThemeProvider>
   );
 
   // HELPERS

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 // Libs
 import * as React from "react";
-import axios from 'axios';
-import { ThemeProvider } from '@material-ui/core/styles';
+import axios from "axios";
+import { ThemeProvider } from "@material-ui/core/styles";
 import { Grid, ButtonGroup, Button } from "@material-ui/core";
 import "@fontsource/roboto";
 import "@fontsource/material-icons";
@@ -17,92 +17,111 @@ import "./App.css";
 import { theme } from "./theme";
 
 export default function App() {
-  // Definitions
-  const [cleanTransactions, setCleanTransactions] = React.useState<
-    iTransaction[]
-  >([]);
+	// Definitions
+	const [cleanTransactions, setCleanTransactions] = React.useState<
+		iTransaction[]
+	>([]);
 
-  const tabs = {
-    0: <Charts></Charts>,
-    1: <Grids cleanTransactions={cleanTransactions}></Grids>,
-    2: <Transactions cleanTransactions={cleanTransactions}></Transactions>,
-  };
+	const tabs = {
+		0: <Charts></Charts>,
+		1: <Grids cleanTransactions={cleanTransactions}></Grids>,
+		2: <Transactions cleanTransactions={cleanTransactions}></Transactions>,
+	};
 
-  type tabOptions = keyof typeof tabs;
+	type tabOptions = keyof typeof tabs;
 
-  const [currentTab, setCurrentTab] = React.useState<tabOptions>(1);
+	const [currentTab, setCurrentTab] = React.useState<tabOptions>(1);
 
+	// LOADING
+	React.useEffect(() => {
+		getGSheetData();
+	}, []);
 
+	console.log("Clean transactions: ", cleanTransactions);
+	// RENDER
+	return (
+		<ThemeProvider theme={theme}>
+			<div className="App">
+				<header className="App-header">
+					<Grid container>
+						<Grid item xs={6}>
+							<h1>Mony mony</h1>
+						</Grid>
+						<Grid item xs={6}>
+							<ButtonGroup variant="contained" color="primary">
+								<Button
+									onClick={() => {
+										getGSheetData();
+									}}
+								>
+									<span className="material-icons">refresh</span>
+								</Button>
+								<Button
+									onClick={() => {
+										setCurrentTab(0);
+									}}
+								>
+									<span className="material-icons">insights</span>
+									&nbsp;&nbsp;Chart
+								</Button>
+								<Button
+									onClick={() => {
+										setCurrentTab(1);
+									}}
+								>
+									<span className="material-icons">apps</span>&nbsp;&nbsp;Grid
+								</Button>
+								<Button
+									onClick={() => {
+										setCurrentTab(2);
+									}}
+								>
+									<span className="material-icons">segment</span>
+									&nbsp;&nbsp;Transactions
+								</Button>
+							</ButtonGroup>
+						</Grid>
+					</Grid>
+				</header>
+				<div className="App-body">{tabs[currentTab]}</div>
+			</div>
+		</ThemeProvider>
+	);
 
-  // LOADING
-  React.useEffect(() => {
-    getGSheetData();
-  }, []);
-
-  console.log("Clean transactions: ", cleanTransactions);
-  // RENDER
-  return (
-    <ThemeProvider theme={theme}>
-    <div className="App">
-      <header className="App-header">
-        <Grid container>
-          <Grid item xs={6}>
-            <h1>Mony mony</h1>
-          </Grid>
-          <Grid item xs={6}>
-            <ButtonGroup variant="contained" color="primary">
-              <Button
-                onClick={() => {
-                  getGSheetData();
-                }}
-              >
-                <span className="material-icons">refresh</span>
-              </Button>
-              <Button
-                onClick={() => {
-                  setCurrentTab(0);
-                }}
-              >
-                <span className="material-icons">insights</span>&nbsp;&nbsp;Chart
-              </Button>
-              <Button
-                onClick={() => {
-                  setCurrentTab(1);
-                }}
-              >
-                <span className="material-icons">apps</span>&nbsp;&nbsp;Grid
-              </Button>
-              <Button
-                onClick={() => {
-                  setCurrentTab(2);
-                }}
-              >
-                <span className="material-icons">segment</span>&nbsp;&nbsp;Transactions
-              </Button>
-            </ButtonGroup>
-          </Grid>
-        </Grid>
-      </header>
-      <div className="App-body">{tabs[currentTab]}</div>
-    </div>
-    </ThemeProvider>
-  );
-
-  // HELPERS
-  function getGSheetData() {
-    axios.get(`${process.env.REACT_APP_GSHEET_URL}?key=${process.env.REACT_APP_GAPI_KEY}`)
-    .then(res => {
-      const data = res.data;
-      setCleanTransactions(
-        data.values
-          .slice(1)
-          .map(([index, date, description, , , amount, category]: [number, string, string, any, any, string, category]) =>
-            {return {index, date, description, category, amount: parseInt(amount)};}
-          )
-      )
-    })
-    .catch((err) => {
-      console.log("error");
-    });
-  }
+	// HELPERS
+	function getGSheetData() {
+		axios
+			.get(
+				`${process.env.REACT_APP_GSHEET_URL}?key=${process.env.REACT_APP_GAPI_KEY}`
+			)
+			.then((res) => {
+				const data = res.data;
+				setCleanTransactions(
+					data.values
+						.slice(1)
+						.map(
+							([index, date, description, , , amount, category]: [
+								number,
+								string,
+								string,
+								any,
+								any,
+								string,
+								category
+							]) => {
+								return {
+									index,
+									date,
+									description,
+									category,
+									amount: parseInt(amount),
+								};
+							}
+						)
+				);
+			})
+			.catch((err) => {
+				console.log("error");
+			});
+	}
 }

--- a/src/components/Grids/GridCell.tsx
+++ b/src/components/Grids/GridCell.tsx
@@ -1,19 +1,28 @@
 // Libs
-import {TableCell} from '@material-ui/core';
+import { TableCell } from "@material-ui/core";
 
-export default function GridCell({value, type}: {value: number, type: string}) {
-  const cellStyle: {[key: string]: string} = {};
+export default function GridCell({
+	value,
+	type,
+}: {
+	value: number;
+	type: string;
+}) {
+	const cellStyle: { [key: string]: string } = {};
 
-  if(value === 0) {
-    cellStyle.color = "#aaa";
-  }
+	if (value === 0) {
+		cellStyle.color = "#aaa";
+	}
 
-  if(type === "total") {
-    cellStyle.background = "#C1D2D9";
-  }
-  else if (type === "profit") {
-    cellStyle.background = value < 0 ? "#D98680" : "#D3D9A7";
-  }
+	if (type === "total") {
+		cellStyle.background = "#C1D2D9";
+	} else if (type === "profit") {
+		cellStyle.background = value < 0 ? "#D98680" : "#D3D9A7";
+	}
 
-  return <TableCell align="right" style={cellStyle}>{value.toLocaleString('en')}</TableCell>;
+	return (
+		<TableCell align="right" style={cellStyle}>
+			{value.toLocaleString("en")}
+		</TableCell>
+	);
 }

--- a/src/components/Grids/GridCell.tsx
+++ b/src/components/Grids/GridCell.tsx
@@ -1,0 +1,19 @@
+// Libs
+import {TableCell} from '@material-ui/core';
+
+export default function GridCell({value, type}: {value: number, type: string}) {
+  const cellStyle: {[key: string]: string} = {};
+
+  if(value === 0) {
+    cellStyle.color = "#aaa";
+  }
+
+  if(type === "total") {
+    cellStyle.background = "#C1D2D9";
+  }
+  else if (type === "profit") {
+    cellStyle.background = value < 0 ? "#D98680" : "#D3D9A7";
+  }
+
+  return <TableCell align="right" style={cellStyle}>{value.toLocaleString('en')}</TableCell>;
+}

--- a/src/components/Grids/Grids.tsx
+++ b/src/components/Grids/Grids.tsx
@@ -3,6 +3,9 @@ import * as React from "react";
 import {TableContainer, Table, TableHead, TableBody, TableRow, TableCell} from '@material-ui/core';
 import {iTransaction, gridRowModel, iGridData, monthModel} from '../../types';
 
+// Components
+import GridCell from "./GridCell";
+
 export default function Grids({cleanTransactions}: {cleanTransactions: iTransaction[]}) {
   // Definitions
   const [gridData, setGridData] = React.useState<
@@ -66,19 +69,19 @@ export default function Grids({cleanTransactions}: {cleanTransactions: iTransact
           <TableHead>
             <TableRow>
               <TableCell></TableCell>
-              <TableCell>January</TableCell>
-              <TableCell>February</TableCell>
-              <TableCell>March</TableCell>
-              <TableCell>April</TableCell>
-              <TableCell>May</TableCell>
-              <TableCell>June</TableCell>
-              <TableCell>July</TableCell>
-              <TableCell>August</TableCell>
-              <TableCell>September</TableCell>
-              <TableCell>October</TableCell>
-              <TableCell>November</TableCell>
-              <TableCell>December</TableCell>
-              <TableCell>TOTAL</TableCell>
+              <TableCell align="right">January</TableCell>
+              <TableCell align="right">February</TableCell>
+              <TableCell align="right">March</TableCell>
+              <TableCell align="right">April</TableCell>
+              <TableCell align="right">May</TableCell>
+              <TableCell align="right">June</TableCell>
+              <TableCell align="right">July</TableCell>
+              <TableCell align="right">August</TableCell>
+              <TableCell align="right">September</TableCell>
+              <TableCell align="right">October</TableCell>
+              <TableCell align="right">November</TableCell>
+              <TableCell align="right">December</TableCell>
+              <TableCell align="right">TOTAL</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -86,7 +89,7 @@ export default function Grids({cleanTransactions}: {cleanTransactions: iTransact
             Object.keys(gridRowModel).map(groupItem => {
               return(
                 <>
-                  <TableRow ><TableCell>{groupItem}</TableCell></TableRow>
+                  <TableRow><TableCell variant="head">{groupItem}</TableCell></TableRow>
                   {
                     Object.keys(gridRowModel[groupItem]).map((categoryItem) => {
                       return (
@@ -98,11 +101,11 @@ export default function Grids({cleanTransactions}: {cleanTransactions: iTransact
                     })
                   }
                   <TableRow >
-                    <TableCell>Total: {groupItem}</TableCell>
+                    <TableCell variant="head">Total</TableCell>
                     <TotalCells group={groupItem}></TotalCells>
                   </TableRow>
                   <TableRow >
-                    <TableCell>Profit after {groupItem}</TableCell>
+                    <TableCell variant="head">Profit</TableCell>
                     <ProfitCells group={groupItem}></ProfitCells>
                   </TableRow>
                   <TableRow ><TableCell>---</TableCell></TableRow>
@@ -111,7 +114,7 @@ export default function Grids({cleanTransactions}: {cleanTransactions: iTransact
             })
           }
             <TableRow>
-              <TableCell>Final income</TableCell>
+              <TableCell variant="head">Final income</TableCell>
               <ProfitCells group="Investments"></ProfitCells>
             </TableRow>
           </TableBody>
@@ -129,7 +132,7 @@ export default function Grids({cleanTransactions}: {cleanTransactions: iTransact
       return (
         <>
         {
-          gridData[category].map(amountItem => <TableCell>{amountItem}</TableCell>)
+          gridData[category].map(amountItem => <GridCell value={amountItem} type="category"></GridCell>)
         }
         </>
       )
@@ -144,7 +147,7 @@ export default function Grids({cleanTransactions}: {cleanTransactions: iTransact
       return (
         <>
         {
-          gridData[`Total ${group}`].map(amount =>  <TableCell>{amount}</TableCell>)
+          gridData[`Total ${group}`].map(amount =>  <GridCell value={amount} type="total"></GridCell>)
         }
         </>
       );
@@ -159,7 +162,7 @@ export default function Grids({cleanTransactions}: {cleanTransactions: iTransact
       return (
         <>
         {
-          gridData[`Profit ${group}`].map(amount => <TableCell>{amount}</TableCell>)
+          gridData[`Profit ${group}`].map(amount => <GridCell value={amount} type="profit"></GridCell>)
         }
         </>
       );

--- a/src/components/Grids/Grids.tsx
+++ b/src/components/Grids/Grids.tsx
@@ -96,7 +96,9 @@ export default function Grids({
 						<TableRow>
 							<TableCell></TableCell>
 							{configMonths.map((columnValue) => (
-								<TableCell align="right">{columnValue}</TableCell>
+								<TableCell key={columnValue} align="right">
+									{columnValue}
+								</TableCell>
 							))}
 							<TableCell>Total</TableCell>
 						</TableRow>
@@ -105,27 +107,39 @@ export default function Grids({
 					<TableBody>
 						{configGroups.map((group) => (
 							<>
-								<TableRow>
+								<TableRow key={group.name}>
 									<TableCell variant="head">{group.name}</TableCell>
 								</TableRow>
 								{group.categories.map((category) => (
-									<TableRow>
+									<TableRow key={category}>
 										<TableCell>{category}</TableCell>
-										{gridData[category]?.map((amount) => (
-											<GridCell value={amount} type="category"></GridCell>
+										{gridData[category]?.map((amount, index) => (
+											<GridCell
+												key={`${category}_${index}`}
+												value={amount}
+												type="category"
+											></GridCell>
 										))}
 									</TableRow>
 								))}
 								<TableRow>
 									<TableCell>Total</TableCell>
-									{gridData[`Total ${group.name}`]?.map((amount) => (
-										<GridCell value={amount} type="total"></GridCell>
+									{gridData[`Total ${group.name}`]?.map((amount, index) => (
+										<GridCell
+											key={`${group.name}_${index}`}
+											value={amount}
+											type="total"
+										></GridCell>
 									))}
 								</TableRow>
 								<TableRow>
 									<TableCell>Profit</TableCell>
-									{gridData[`Profit ${group.name}`]?.map((amount) => (
-										<GridCell value={amount} type="profit"></GridCell>
+									{gridData[`Profit ${group.name}`]?.map((amount, index) => (
+										<GridCell
+											key={`${group.name}_${index}`}
+											value={amount}
+											type="profit"
+										></GridCell>
 									))}
 								</TableRow>
 								<TableRow>

--- a/src/components/Grids/Grids.tsx
+++ b/src/components/Grids/Grids.tsx
@@ -1,4 +1,112 @@
-export default function Grids() {
+// Libs
+import * as React from "react";
+import {TableContainer, Table, TableHead, TableBody, TableRow, TableCell} from '@material-ui/core';
+import {iTransaction, gridRowModel, iGridData, monthModel} from '../../types';
+
+export default function Grids({cleanTransactions}: {cleanTransactions: iTransaction[]}) {
+  // Definitions
+  const [gridData, setGridData] = React.useState<
+    iGridData
+  >({});
+
+  // LOADING
+  React.useEffect(() => {
+    const newGrid: iGridData = {};
+    for (const transactionItem of cleanTransactions) {
+      if (newGrid[transactionItem.category] === undefined) {
+        newGrid[transactionItem.category] = new Array(12).fill(0);
+      }
+      newGrid[transactionItem.category][parseInt(transactionItem.date.split('.')[1]) - 1] += transactionItem.amount;
+    }
+    console.log(newGrid);
+    setGridData(newGrid);
+  }, [cleanTransactions]);
+
   // RENDER
-  return <div className="Grids">Grids</div>;
+  return (
+    <div className="Grids">
+      <h2>Grid</h2>
+      <TableContainer>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell></TableCell>
+              <TableCell>January</TableCell>
+              <TableCell>February</TableCell>
+              <TableCell>March</TableCell>
+              <TableCell>April</TableCell>
+              <TableCell>May</TableCell>
+              <TableCell>June</TableCell>
+              <TableCell>July</TableCell>
+              <TableCell>August</TableCell>
+              <TableCell>September</TableCell>
+              <TableCell>October</TableCell>
+              <TableCell>November</TableCell>
+              <TableCell>December</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+          {
+            Object.keys(gridRowModel).map(groupItem => {
+              return(
+                <>
+                  <TableRow ><TableCell>{groupItem}</TableCell></TableRow>
+                  {
+                    Object.keys(gridRowModel[groupItem]).map((categoryItem) => {
+                      return (
+                        <TableRow>
+                          <TableCell>{categoryItem}</TableCell>
+                          <AmountCells category={categoryItem}></AmountCells>
+                        </TableRow>
+                      )
+                    })
+                  }
+                  <TableRow >
+                    <TableCell>Total: {groupItem}</TableCell>
+                    <TotalCells group={groupItem}></TotalCells>
+                  </TableRow>
+                  <TableRow ><TableCell>---</TableCell></TableRow>
+                </>
+              )
+            })
+          }
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </div>
+  )
+
+  // HELPER COMPS
+  function AmountCells({category}: {category: string}) {
+    if(gridData[category] === undefined) {
+      return <></>;
+    }
+    else {
+      return (
+        <>
+        {
+          gridData[category].map(amountItem => <TableCell>{amountItem}</TableCell>)
+        }
+        </>
+      )
+    }
+  }
+
+  function TotalCells({group}: {group: string}) {
+    const catList = Object.keys(gridRowModel[group]);
+
+    return (
+      <>
+      {
+        monthModel.map(month => {
+          let currentTot = 0;
+          for(const cat of catList) {
+            currentTot += gridData[cat] === undefined ? 0 : gridData[cat][month - 1];
+          }
+          return <TableCell>{currentTot}</TableCell>;
+        })
+      }
+      </>
+    );
+  }
 }

--- a/src/components/Grids/Grids.tsx
+++ b/src/components/Grids/Grids.tsx
@@ -12,14 +12,16 @@ export default function Grids({cleanTransactions}: {cleanTransactions: iTransact
   // LOADING
   React.useEffect(() => {
     const newGrid: iGridData = {};
+    // Build empty grid
     for (const group of Object.keys(gridRowModel)) {
-      newGrid[`Total ${group}`] = new Array(12).fill(0);
-      newGrid[`Profit ${group}`] = new Array(12).fill(0);;
+      newGrid[`Total ${group}`] = new Array(13).fill(0);
+      newGrid[`Profit ${group}`] = new Array(13).fill(0);;
       for (const category of Object.keys(gridRowModel[group])) {
-        newGrid[category] = new Array(12).fill(0);
+        newGrid[category] = new Array(13).fill(0);
       }
     }
 
+    // Add category data
     for (const transactionItem of cleanTransactions) {
       if (newGrid[transactionItem.category] === undefined) {
         throw new Error(`Missing category: ${transactionItem.category}`);
@@ -27,6 +29,7 @@ export default function Grids({cleanTransactions}: {cleanTransactions: iTransact
       newGrid[transactionItem.category][parseInt(transactionItem.date.split('.')[1]) - 1] += transactionItem.amount;
     }
 
+    // Add total and profit for each group
     const currentProfits = [...newGrid['Total Revenues']];
     for (const group of Object.keys(gridRowModel)) {
       for(const month of monthModel) {
@@ -38,6 +41,15 @@ export default function Grids({cleanTransactions}: {cleanTransactions: iTransact
         newGrid[`Total ${group}`][month - 1] = currentTot;
         newGrid[`Profit ${group}`][month - 1] = currentProfits[month - 1];
       }
+    }
+
+    // Add total for each row
+    for (const rowKey of Object.keys(newGrid)) {
+      let totalRow = 0;
+      for(let i = 0; i < 12; i++) {
+        totalRow += newGrid[rowKey][i];
+      }
+      newGrid[rowKey][12] = totalRow;
     }
 
     console.log('griddata: ', newGrid);
@@ -66,6 +78,7 @@ export default function Grids({cleanTransactions}: {cleanTransactions: iTransact
               <TableCell>October</TableCell>
               <TableCell>November</TableCell>
               <TableCell>December</TableCell>
+              <TableCell>TOTAL</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>

--- a/src/components/Grids/Grids.tsx
+++ b/src/components/Grids/Grids.tsx
@@ -1,171 +1,179 @@
 // Libs
 import * as React from "react";
-import {TableContainer, Table, TableHead, TableBody, TableRow, TableCell} from '@material-ui/core';
-import {iTransaction, gridRowModel, iGridData, monthModel} from '../../types';
+import {
+	TableContainer,
+	Table,
+	TableHead,
+	TableBody,
+	TableRow,
+	TableCell,
+} from "@material-ui/core";
+import { iTransaction, gridRowModel, iGridData, monthModel } from "../../types";
 
 // Components
 import GridCell from "./GridCell";
 
-export default function Grids({cleanTransactions}: {cleanTransactions: iTransaction[]}) {
-  // Definitions
-  const [gridData, setGridData] = React.useState<
-    iGridData
-  >({});
+export default function Grids({
+	cleanTransactions,
+}: {
+	cleanTransactions: iTransaction[];
+}) {
+	// Definitions
+	const [gridData, setGridData] = React.useState<iGridData>({});
 
-  // LOADING
-  React.useEffect(() => {
-    const newGrid: iGridData = {};
-    // Build empty grid
-    for (const group of Object.keys(gridRowModel)) {
-      newGrid[`Total ${group}`] = new Array(13).fill(0);
-      newGrid[`Profit ${group}`] = new Array(13).fill(0);;
-      for (const category of Object.keys(gridRowModel[group])) {
-        newGrid[category] = new Array(13).fill(0);
-      }
-    }
+	// LOADING
+	React.useEffect(() => {
+		const newGrid: iGridData = {};
+		// Build empty grid
+		for (const group of Object.keys(gridRowModel)) {
+			newGrid[`Total ${group}`] = new Array(13).fill(0);
+			newGrid[`Profit ${group}`] = new Array(13).fill(0);
+			for (const category of Object.keys(gridRowModel[group])) {
+				newGrid[category] = new Array(13).fill(0);
+			}
+		}
 
-    // Add category data
-    for (const transactionItem of cleanTransactions) {
-      if (newGrid[transactionItem.category] === undefined) {
-        throw new Error(`Missing category: ${transactionItem.category}`);
-      }
-      newGrid[transactionItem.category][parseInt(transactionItem.date.split('.')[1]) - 1] += transactionItem.amount;
-    }
+		// Add category data
+		for (const transactionItem of cleanTransactions) {
+			if (newGrid[transactionItem.category] === undefined) {
+				throw new Error(`Missing category: ${transactionItem.category}`);
+			}
+			newGrid[transactionItem.category][
+				parseInt(transactionItem.date.split(".")[1]) - 1
+			] += transactionItem.amount;
+		}
 
-    // Add total and profit for each group
-    const currentProfits = [...newGrid['Total Revenues']];
-    for (const group of Object.keys(gridRowModel)) {
-      for(const month of monthModel) {
-        let currentTot = 0;
-        for (const category of Object.keys(gridRowModel[group])) {
-          currentTot += newGrid[category][month - 1];
-        }
-        currentProfits[month - 1] += currentTot;
-        newGrid[`Total ${group}`][month - 1] = currentTot;
-        newGrid[`Profit ${group}`][month - 1] = currentProfits[month - 1];
-      }
-    }
+		// Add total and profit for each group
+		const currentProfits = [...newGrid["Total Revenues"]];
+		for (const group of Object.keys(gridRowModel)) {
+			for (const month of monthModel) {
+				let currentTot = 0;
+				for (const category of Object.keys(gridRowModel[group])) {
+					currentTot += newGrid[category][month - 1];
+				}
+				currentProfits[month - 1] += currentTot;
+				newGrid[`Total ${group}`][month - 1] = currentTot;
+				newGrid[`Profit ${group}`][month - 1] = currentProfits[month - 1];
+			}
+		}
 
-    // Add total for each row
-    for (const rowKey of Object.keys(newGrid)) {
-      let totalRow = 0;
-      for(let i = 0; i < 12; i++) {
-        totalRow += newGrid[rowKey][i];
-      }
-      newGrid[rowKey][12] = totalRow;
-    }
+		// Add total for each row
+		for (const rowKey of Object.keys(newGrid)) {
+			let totalRow = 0;
+			for (let i = 0; i < 12; i++) {
+				totalRow += newGrid[rowKey][i];
+			}
+			newGrid[rowKey][12] = totalRow;
+		}
 
-    console.log('griddata: ', newGrid);
+		console.log("griddata: ", newGrid);
 
-    setGridData(newGrid);
-  }, [cleanTransactions]);
+		setGridData(newGrid);
+	}, [cleanTransactions]);
 
-  // RENDER
-  return (
-    <div className="Grids">
-      <h2>Grid</h2>
-      <TableContainer>
-        <Table size="small">
-          <TableHead>
-            <TableRow>
-              <TableCell></TableCell>
-              <TableCell align="right">January</TableCell>
-              <TableCell align="right">February</TableCell>
-              <TableCell align="right">March</TableCell>
-              <TableCell align="right">April</TableCell>
-              <TableCell align="right">May</TableCell>
-              <TableCell align="right">June</TableCell>
-              <TableCell align="right">July</TableCell>
-              <TableCell align="right">August</TableCell>
-              <TableCell align="right">September</TableCell>
-              <TableCell align="right">October</TableCell>
-              <TableCell align="right">November</TableCell>
-              <TableCell align="right">December</TableCell>
-              <TableCell align="right">TOTAL</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-          {
-            Object.keys(gridRowModel).map(groupItem => {
-              return(
-                <>
-                  <TableRow><TableCell variant="head">{groupItem}</TableCell></TableRow>
-                  {
-                    Object.keys(gridRowModel[groupItem]).map((categoryItem) => {
-                      return (
-                        <TableRow>
-                          <TableCell>{categoryItem}</TableCell>
-                          <AmountCells category={categoryItem}></AmountCells>
-                        </TableRow>
-                      )
-                    })
-                  }
-                  <TableRow >
-                    <TableCell variant="head">Total</TableCell>
-                    <TotalCells group={groupItem}></TotalCells>
-                  </TableRow>
-                  <TableRow >
-                    <TableCell variant="head">Profit</TableCell>
-                    <ProfitCells group={groupItem}></ProfitCells>
-                  </TableRow>
-                  <TableRow ><TableCell>---</TableCell></TableRow>
-                </>
-              )
-            })
-          }
-            <TableRow>
-              <TableCell variant="head">Final income</TableCell>
-              <ProfitCells group="Investments"></ProfitCells>
-            </TableRow>
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </div>
-  )
+	// RENDER
+	return (
+		<div className="Grids">
+			<h2>Grid</h2>
+			<TableContainer>
+				<Table size="small">
+					<TableHead>
+						<TableRow>
+							<TableCell></TableCell>
+							<TableCell align="right">January</TableCell>
+							<TableCell align="right">February</TableCell>
+							<TableCell align="right">March</TableCell>
+							<TableCell align="right">April</TableCell>
+							<TableCell align="right">May</TableCell>
+							<TableCell align="right">June</TableCell>
+							<TableCell align="right">July</TableCell>
+							<TableCell align="right">August</TableCell>
+							<TableCell align="right">September</TableCell>
+							<TableCell align="right">October</TableCell>
+							<TableCell align="right">November</TableCell>
+							<TableCell align="right">December</TableCell>
+							<TableCell align="right">TOTAL</TableCell>
+						</TableRow>
+					</TableHead>
+					<TableBody>
+						{Object.keys(gridRowModel).map((groupItem) => {
+							return (
+								<>
+									<TableRow>
+										<TableCell variant="head">{groupItem}</TableCell>
+									</TableRow>
+									{Object.keys(gridRowModel[groupItem]).map((categoryItem) => {
+										return (
+											<TableRow>
+												<TableCell>{categoryItem}</TableCell>
+												<AmountCells category={categoryItem}></AmountCells>
+											</TableRow>
+										);
+									})}
+									<TableRow>
+										<TableCell variant="head">Total</TableCell>
+										<TotalCells group={groupItem}></TotalCells>
+									</TableRow>
+									<TableRow>
+										<TableCell variant="head">Profit</TableCell>
+										<ProfitCells group={groupItem}></ProfitCells>
+									</TableRow>
+									<TableRow>
+										<TableCell>---</TableCell>
+									</TableRow>
+								</>
+							);
+						})}
+						<TableRow>
+							<TableCell variant="head">Final income</TableCell>
+							<ProfitCells group="Investments"></ProfitCells>
+						</TableRow>
+					</TableBody>
+				</Table>
+			</TableContainer>
+		</div>
+	);
 
-  // HELPER COMPS
-  function AmountCells({category}: {category: string}) {
-    if(gridData[category] === undefined) {
-      return <></>;
-    }
-    else {
-      return (
-        <>
-        {
-          gridData[category].map(amountItem => <GridCell value={amountItem} type="category"></GridCell>)
-        }
-        </>
-      )
-    }
-  }
+	// HELPER COMPS
+	function AmountCells({ category }: { category: string }) {
+		if (gridData[category] === undefined) {
+			return <></>;
+		} else {
+			return (
+				<>
+					{gridData[category].map((amountItem) => (
+						<GridCell value={amountItem} type="category"></GridCell>
+					))}
+				</>
+			);
+		}
+	}
 
-  function TotalCells({group}: {group: string}) {
-    if(gridData[`Total ${group}`] === undefined) {
-      return <></>;
-    }
-    else {
-      return (
-        <>
-        {
-          gridData[`Total ${group}`].map(amount =>  <GridCell value={amount} type="total"></GridCell>)
-        }
-        </>
-      );
-    }
-  }
+	function TotalCells({ group }: { group: string }) {
+		if (gridData[`Total ${group}`] === undefined) {
+			return <></>;
+		} else {
+			return (
+				<>
+					{gridData[`Total ${group}`].map((amount) => (
+						<GridCell value={amount} type="total"></GridCell>
+					))}
+				</>
+			);
+		}
+	}
 
-  function ProfitCells({group}: {group: string}) {
-    if(gridData[`Profit ${group}`] === undefined) {
-      return <></>;
-    }
-    else {
-      return (
-        <>
-        {
-          gridData[`Profit ${group}`].map(amount => <GridCell value={amount} type="profit"></GridCell>)
-        }
-        </>
-      );
-    }
-  }
+	function ProfitCells({ group }: { group: string }) {
+		if (gridData[`Profit ${group}`] === undefined) {
+			return <></>;
+		} else {
+			return (
+				<>
+					{gridData[`Profit ${group}`].map((amount) => (
+						<GridCell value={amount} type="profit"></GridCell>
+					))}
+				</>
+			);
+		}
+	}
 }

--- a/src/components/Grids/Grids.tsx
+++ b/src/components/Grids/Grids.tsx
@@ -8,7 +8,8 @@ import {
 	TableRow,
 	TableCell,
 } from "@material-ui/core";
-import { iTransaction, gridRowModel, iGridData, monthModel } from "../../types";
+import { iTransaction, gridRowModel, iGridData } from "../../types";
+import { configColumns } from "../../types";
 
 // Components
 import GridCell from "./GridCell";
@@ -26,10 +27,10 @@ export default function Grids({
 		const newGrid: iGridData = {};
 		// Build empty grid
 		for (const group of Object.keys(gridRowModel)) {
-			newGrid[`Total ${group}`] = new Array(13).fill(0);
-			newGrid[`Profit ${group}`] = new Array(13).fill(0);
+			newGrid[`Total ${group}`] = new Array(configColumns.length + 1).fill(0);
+			newGrid[`Profit ${group}`] = new Array(configColumns.length + 1).fill(0);
 			for (const category of Object.keys(gridRowModel[group])) {
-				newGrid[category] = new Array(13).fill(0);
+				newGrid[category] = new Array(configColumns.length + 1).fill(0);
 			}
 		}
 
@@ -46,24 +47,28 @@ export default function Grids({
 		// Add total and profit for each group
 		const currentProfits = [...newGrid["Total Revenues"]];
 		for (const group of Object.keys(gridRowModel)) {
-			for (const month of monthModel) {
+			for (
+				let columnIndex = 0;
+				columnIndex < configColumns.length;
+				columnIndex++
+			) {
 				let currentTot = 0;
 				for (const category of Object.keys(gridRowModel[group])) {
-					currentTot += newGrid[category][month - 1];
+					currentTot += newGrid[category][columnIndex];
 				}
-				currentProfits[month - 1] += currentTot;
-				newGrid[`Total ${group}`][month - 1] = currentTot;
-				newGrid[`Profit ${group}`][month - 1] = currentProfits[month - 1];
+				currentProfits[columnIndex] += currentTot;
+				newGrid[`Total ${group}`][columnIndex] = currentTot;
+				newGrid[`Profit ${group}`][columnIndex] = currentProfits[columnIndex];
 			}
 		}
 
 		// Add total for each row
 		for (const rowKey of Object.keys(newGrid)) {
 			let totalRow = 0;
-			for (let i = 0; i < 12; i++) {
+			for (let i = 0; i < configColumns.length; i++) {
 				totalRow += newGrid[rowKey][i];
 			}
-			newGrid[rowKey][12] = totalRow;
+			newGrid[rowKey][configColumns.length] = totalRow;
 		}
 
 		console.log("griddata: ", newGrid);
@@ -73,26 +78,17 @@ export default function Grids({
 
 	// RENDER
 	return (
-		<div className="Grids">
+		<>
 			<h2>Grid</h2>
 			<TableContainer>
 				<Table size="small">
 					<TableHead>
 						<TableRow>
 							<TableCell></TableCell>
-							<TableCell align="right">January</TableCell>
-							<TableCell align="right">February</TableCell>
-							<TableCell align="right">March</TableCell>
-							<TableCell align="right">April</TableCell>
-							<TableCell align="right">May</TableCell>
-							<TableCell align="right">June</TableCell>
-							<TableCell align="right">July</TableCell>
-							<TableCell align="right">August</TableCell>
-							<TableCell align="right">September</TableCell>
-							<TableCell align="right">October</TableCell>
-							<TableCell align="right">November</TableCell>
-							<TableCell align="right">December</TableCell>
-							<TableCell align="right">TOTAL</TableCell>
+							{configColumns.map((columnValue) => (
+								<TableCell align="right">{columnValue}</TableCell>
+							))}
+							<TableCell>Total</TableCell>
 						</TableRow>
 					</TableHead>
 					<TableBody>
@@ -119,7 +115,7 @@ export default function Grids({
 										<ProfitCells group={groupItem}></ProfitCells>
 									</TableRow>
 									<TableRow>
-										<TableCell>---</TableCell>
+										<TableCell>&nbsp;</TableCell>
 									</TableRow>
 								</>
 							);
@@ -131,7 +127,7 @@ export default function Grids({
 					</TableBody>
 				</Table>
 			</TableContainer>
-		</div>
+		</>
 	);
 
 	// HELPER COMPS

--- a/src/components/Transactions/Transactions.tsx
+++ b/src/components/Transactions/Transactions.tsx
@@ -1,47 +1,49 @@
 // Libs
 import {
-  TableContainer,
-  Table,
-  TableHead,
-  TableBody,
-  TableRow,
-  TableCell,
+	TableContainer,
+	Table,
+	TableHead,
+	TableBody,
+	TableRow,
+	TableCell,
 } from "@material-ui/core";
 import { iTransaction } from "../../types";
 
 export default function Transactions({
-  cleanTransactions,
+	cleanTransactions,
 }: {
-  cleanTransactions: iTransaction[];
+	cleanTransactions: iTransaction[];
 }) {
-  // RENDER
-  return (
-    <div className="Transactions">
-      <h2>Transactions</h2>
-      <TableContainer>
-        <Table size="small">
-          <TableHead>
-            <TableRow className="TransactionsRow">
-              <TableCell>Index</TableCell>
-              <TableCell>Date</TableCell>
-              <TableCell>Description</TableCell>
-              <TableCell>Category</TableCell>
-              <TableCell>Amount</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {cleanTransactions.map(({index, date, description, category, amount}) => (
-              <TableRow key={index} className="TransactionsRow">
-                <TableCell>{index}</TableCell>
-                <TableCell>{date}</TableCell>
-                <TableCell>{description}</TableCell>
-                <TableCell>{category}</TableCell>
-                <TableCell>{amount}</TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </div>
-  );
+	// RENDER
+	return (
+		<div className="Transactions">
+			<h2>Transactions</h2>
+			<TableContainer>
+				<Table size="small">
+					<TableHead>
+						<TableRow className="TransactionsRow">
+							<TableCell>Index</TableCell>
+							<TableCell>Date</TableCell>
+							<TableCell>Description</TableCell>
+							<TableCell>Category</TableCell>
+							<TableCell>Amount</TableCell>
+						</TableRow>
+					</TableHead>
+					<TableBody>
+						{cleanTransactions.map(
+							({ index, date, description, category, amount }) => (
+								<TableRow key={index} className="TransactionsRow">
+									<TableCell>{index}</TableCell>
+									<TableCell>{date}</TableCell>
+									<TableCell>{description}</TableCell>
+									<TableCell>{category}</TableCell>
+									<TableCell>{amount}</TableCell>
+								</TableRow>
+							)
+						)}
+					</TableBody>
+				</Table>
+			</TableContainer>
+		</div>
+	);
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,10 +5,10 @@ import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 
 ReactDOM.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-  document.getElementById("root")
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>,
+	document.getElementById("root")
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,11 +1,11 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createMuiTheme } from "@material-ui/core/styles";
 
 export const theme = createMuiTheme({
-  overrides: {
-    MuiTableCell: {
-      head: {
-        fontWeight: 'bold',
-      },
-    },
-  },
+	overrides: {
+		MuiTableCell: {
+			head: {
+				fontWeight: "bold",
+			},
+		},
+	},
 });

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,0 +1,11 @@
+import { createMuiTheme } from '@material-ui/core/styles';
+
+export const theme = createMuiTheme({
+  overrides: {
+    MuiTableCell: {
+      head: {
+        fontWeight: 'bold',
+      },
+    },
+  },
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,22 @@
+// TYPES
 export type category =
   | ""
-  | "Restaurants and bars"
-  | "Meal"
-  | "Transport"
-  | "Home";
+  | 'Revenue Alice'
+  | 'Revenue Ivan'
+  | 'Other revenue'
+  | 'Interests'
+  | 'Depreciation'
+  | 'Home'
+  | 'Health'
+  | 'Meal'
+  | 'Transport'
+  | 'Other living'
+  | 'Restaurants and bars'
+  | 'Media'
+  | 'Gift'
+  | 'Holiday'
+  | 'Stuff'
+  | 'Other fun';
 
 export interface iTransaction {
   index: number;
@@ -11,4 +24,42 @@ export interface iTransaction {
   description: string;
   category: category;
   amount: number;
+}
+
+export interface iGridRowModel {
+  [group: string]: {
+    [category: string]: Array<number>
+  }
+}
+
+export interface iGridData {
+  [category: string]: Array<number>
+}
+
+// CONFIGURATION MODELS
+export const monthModel = [1,2,3,4,5,6,7,8,9,10,11,12];
+
+export const gridRowModel: iGridRowModel = {
+  'Revenues': {
+    'Revenue Alice': [],
+    'Revenue Ivan': [],
+    'Other revenue': []
+  },
+  'Costs of living': {
+    'Interests': [],
+    'Depreciation': [],
+    'Home': [],
+    'Health': [],
+    'Meal': [],
+    'Transport': [],
+    'Other living': []
+  },
+  'Costs of fun': {
+    'Restaurants and bars': [],
+    'Media': [],
+    'Gift': [],
+    'Holiday': [],
+    'Stuff': [],
+    'Other fun': []
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,19 +4,21 @@ export type category =
   | 'Revenue Alice'
   | 'Revenue Ivan'
   | 'Other revenue'
-  | 'Interests'
-  | 'Depreciation'
   | 'Home'
   | 'Health'
   | 'Meal'
   | 'Transport'
+  | 'Interests'
   | 'Other living'
   | 'Restaurants and bars'
   | 'Media'
   | 'Gift'
   | 'Holiday'
   | 'Stuff'
-  | 'Other fun';
+  | 'Other fun'
+  | '3a'
+  | 'Home investments'
+  | 'Other investments';
 
 export interface iTransaction {
   index: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
 // TYPES
 export type category =
-	| ""
 	| "Revenue Alice"
 	| "Revenue Ivan"
 	| "Other revenue"
@@ -28,18 +27,18 @@ export interface iTransaction {
 	amount: number;
 }
 
-export interface iGridRowModel {
-	[group: string]: {
-		[category: string]: Array<number>;
-	};
-}
-
 export interface iGridData {
 	[category: string]: Array<number>;
 }
 
+export interface iGroupConfig {
+	name: string;
+	type: "revenues" | "costs";
+	categories: Array<category>;
+}
+
 // CONFIGURATION MODELS
-export const configColumns = [
+export const configMonths = [
 	"January",
 	"February",
 	"March",
@@ -54,31 +53,39 @@ export const configColumns = [
 	"December",
 ];
 
-export const gridRowModel: iGridRowModel = {
-	Revenues: {
-		"Revenue Alice": [],
-		"Revenue Ivan": [],
-		"Other revenue": [],
+export const configGroups: Array<iGroupConfig> = [
+	{
+		name: "Revenues",
+		type: "revenues",
+		categories: ["Revenue Alice", "Revenue Ivan", "Other revenue"],
 	},
-	"Costs of living": {
-		Home: [],
-		Health: [],
-		Meal: [],
-		Transport: [],
-		Interests: [],
-		"Other living": [],
+	{
+		name: "Costs of living",
+		type: "costs",
+		categories: [
+			"Home",
+			"Health",
+			"Meal",
+			"Transport",
+			"Interests",
+			"Other living",
+		],
 	},
-	"Costs of fun": {
-		"Restaurants and bars": [],
-		Media: [],
-		Gift: [],
-		Holiday: [],
-		Stuff: [],
-		"Other fun": [],
+	{
+		name: "Costs of fun",
+		type: "costs",
+		categories: [
+			"Restaurants and bars",
+			"Media",
+			"Gift",
+			"Holiday",
+			"Stuff",
+			"Other fun",
+		],
 	},
-	Investments: {
-		"3a": [],
-		"Home investments": [],
-		"Other investments": [],
+	{
+		name: "Investments",
+		type: "costs",
+		categories: ["3a", "Home investments", "Other investments"],
 	},
-};
+];

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,20 @@ export interface iGridData {
 }
 
 // CONFIGURATION MODELS
-export const monthModel = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+export const configColumns = [
+	"January",
+	"February",
+	"March",
+	"April",
+	"May",
+	"June",
+	"July",
+	"August",
+	"September",
+	"October",
+	"November",
+	"December",
+];
 
 export const gridRowModel: iGridRowModel = {
 	Revenues: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,12 +46,11 @@ export const gridRowModel: iGridRowModel = {
     'Other revenue': []
   },
   'Costs of living': {
-    'Interests': [],
-    'Depreciation': [],
     'Home': [],
     'Health': [],
     'Meal': [],
     'Transport': [],
+    'Interests': [],
     'Other living': []
   },
   'Costs of fun': {
@@ -61,5 +60,10 @@ export const gridRowModel: iGridRowModel = {
     'Holiday': [],
     'Stuff': [],
     'Other fun': []
+  },
+  'Investments': {
+    '3a': [],
+    'Home investments': [],
+    'Other investments': []
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,71 +1,71 @@
 // TYPES
 export type category =
-  | ""
-  | 'Revenue Alice'
-  | 'Revenue Ivan'
-  | 'Other revenue'
-  | 'Home'
-  | 'Health'
-  | 'Meal'
-  | 'Transport'
-  | 'Interests'
-  | 'Other living'
-  | 'Restaurants and bars'
-  | 'Media'
-  | 'Gift'
-  | 'Holiday'
-  | 'Stuff'
-  | 'Other fun'
-  | '3a'
-  | 'Home investments'
-  | 'Other investments';
+	| ""
+	| "Revenue Alice"
+	| "Revenue Ivan"
+	| "Other revenue"
+	| "Home"
+	| "Health"
+	| "Meal"
+	| "Transport"
+	| "Interests"
+	| "Other living"
+	| "Restaurants and bars"
+	| "Media"
+	| "Gift"
+	| "Holiday"
+	| "Stuff"
+	| "Other fun"
+	| "3a"
+	| "Home investments"
+	| "Other investments";
 
 export interface iTransaction {
-  index: number;
-  date: string;
-  description: string;
-  category: category;
-  amount: number;
+	index: number;
+	date: string;
+	description: string;
+	category: category;
+	amount: number;
 }
 
 export interface iGridRowModel {
-  [group: string]: {
-    [category: string]: Array<number>
-  }
+	[group: string]: {
+		[category: string]: Array<number>;
+	};
 }
 
 export interface iGridData {
-  [category: string]: Array<number>
+	[category: string]: Array<number>;
 }
 
 // CONFIGURATION MODELS
-export const monthModel = [1,2,3,4,5,6,7,8,9,10,11,12];
+export const monthModel = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
 
 export const gridRowModel: iGridRowModel = {
-  'Revenues': {
-    'Revenue Alice': [],
-    'Revenue Ivan': [],
-    'Other revenue': []
-  },
-  'Costs of living': {
-    'Home': [],
-    'Health': [],
-    'Meal': [],
-    'Transport': [],
-    'Interests': [],
-    'Other living': []
-  },
-  'Costs of fun': {
-    'Restaurants and bars': [],
-    'Media': [],
-    'Gift': [],
-    'Holiday': [],
-    'Stuff': [],
-    'Other fun': []
-  },
-  'Investments': {
-    '3a': [],
-    'Home investments': [],
-    'Other investments': []
-  }
-}
+	Revenues: {
+		"Revenue Alice": [],
+		"Revenue Ivan": [],
+		"Other revenue": [],
+	},
+	"Costs of living": {
+		Home: [],
+		Health: [],
+		Meal: [],
+		Transport: [],
+		Interests: [],
+		"Other living": [],
+	},
+	"Costs of fun": {
+		"Restaurants and bars": [],
+		Media: [],
+		Gift: [],
+		Holiday: [],
+		Stuff: [],
+		"Other fun": [],
+	},
+	Investments: {
+		"3a": [],
+		"Home investments": [],
+		"Other investments": [],
+	},
+};


### PR DESCRIPTION
## Description

This PR includes v1 of the grid view.

It allows to visualize accounts per month and category, mimicking a financial P&L model.

## Comments

* Grid configurations for month (columns) and categories (rows) are built as const – to potentially allow UI to edit later
* Styling is done all over the place (inline comp, .css, theme), and should be reconciled later
* Build of grid data from transactions list feels very inefficient (lots of loops), maybe other data model would work better